### PR TITLE
Add authentication for sensitive endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,9 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/responsesensitive/configs/SecurityConfig.java
+++ b/src/main/java/com/example/responsesensitive/configs/SecurityConfig.java
@@ -1,0 +1,48 @@
+package com.example.responsesensitive.configs;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(authz -> authz
+                .requestMatchers("/sensitive-infos/**").authenticated()
+                .anyRequest().permitAll()
+            )
+            .httpBasic()
+            .and()
+            .csrf().disable();
+        
+        return http.build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        UserDetails user = User.builder()
+                .username("admin")
+                .password(passwordEncoder().encode("password"))
+                .roles("USER")
+                .build();
+
+        return new InMemoryUserDetailsManager(user);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/responsesensitive/configs/SecurityConfig.java
+++ b/src/main/java/com/example/responsesensitive/configs/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.responsesensitive.configs;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -15,6 +16,12 @@ import org.springframework.security.web.SecurityFilterChain;
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    @Value("${app.security.username}")
+    private String username;
+
+    @Value("${app.security.password}")
+    private String password;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -33,8 +40,8 @@ public class SecurityConfig {
     @Bean
     public UserDetailsService userDetailsService() {
         UserDetails user = User.builder()
-                .username("admin")
-                .password(passwordEncoder().encode("password"))
+                .username(username)
+                .password(passwordEncoder().encode(password))
                 .roles("USER")
                 .build();
 

--- a/src/main/java/com/example/responsesensitive/configs/SecurityConfig.java
+++ b/src/main/java/com/example/responsesensitive/configs/SecurityConfig.java
@@ -19,8 +19,8 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-            .authorizeHttpRequests(authz -> authz
-                .requestMatchers("/sensitive-infos/**").authenticated()
+            .authorizeRequests(authz -> authz
+                .antMatchers("/sensitive-infos/**").authenticated()
                 .anyRequest().permitAll()
             )
             .httpBasic()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 server.port=10080
 
 # Authentication credentials for sensitive endpoints
-# Username: admin
-# Password: password
+app.security.username=admin
+app.security.password=password

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 server.port=10080
+
+# Authentication credentials for sensitive endpoints
+# Username: admin
+# Password: password

--- a/src/test/java/com/example/responsesensitive/SecurityConfigTest.java
+++ b/src/test/java/com/example/responsesensitive/SecurityConfigTest.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -42,7 +43,7 @@ class SecurityConfigTest {
     @Test
     void testUserDetailsServiceHasAdminUser() {
         // Test that admin user exists in user details service
-        var userDetails = userDetailsService.loadUserByUsername("admin");
+        UserDetails userDetails = userDetailsService.loadUserByUsername("admin");
         assertNotNull(userDetails);
         assertTrue(userDetails.getUsername().equals("admin"));
     }

--- a/src/test/java/com/example/responsesensitive/SecurityConfigTest.java
+++ b/src/test/java/com/example/responsesensitive/SecurityConfigTest.java
@@ -1,0 +1,49 @@
+package com.example.responsesensitive;
+
+import com.example.responsesensitive.configs.SecurityConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+class SecurityConfigTest {
+
+    @Autowired
+    private SecurityConfig securityConfig;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private UserDetailsService userDetailsService;
+
+    @Test
+    void testSecurityConfigurationLoads() {
+        // Test that security configuration loads properly
+        assertNotNull(securityConfig);
+        assertNotNull(passwordEncoder);
+        assertNotNull(userDetailsService);
+    }
+
+    @Test
+    void testPasswordEncoderWorks() {
+        // Test that password encoder is functioning
+        String rawPassword = "password";
+        String encodedPassword = passwordEncoder.encode(rawPassword);
+        
+        assertTrue(passwordEncoder.matches(rawPassword, encodedPassword));
+    }
+
+    @Test
+    void testUserDetailsServiceHasAdminUser() {
+        // Test that admin user exists in user details service
+        var userDetails = userDetailsService.loadUserByUsername("admin");
+        assertNotNull(userDetails);
+        assertTrue(userDetails.getUsername().equals("admin"));
+    }
+}


### PR DESCRIPTION
This PR adds authentication for the `/sensitive-infos` endpoint as requested in #3.

## Changes
- Added Spring Security dependency
- Created SecurityConfig with HTTP Basic authentication
- Secured all `/sensitive-infos/**` endpoints
- Set up default credentials (admin/password)
- Added security tests

Resolves #3

Generated with [Claude Code](https://claude.ai/code)